### PR TITLE
Add test for SQLModel field preserving

### DIFF
--- a/partial_tables/partial_table.py
+++ b/partial_tables/partial_table.py
@@ -108,25 +108,14 @@ class PartialSQLModelMixin:
             super().__init_subclass__(**kwargs)
             return
 
-        # Rewrite annotations to Optional[...] and ensure the corresponding Field(...)
-        # value from bases is present on the subclass namespace so SQLModel preserves
-        # unique/index/defaults when mapping.
         type_hints = get_type_hints(cls, include_extras=True)
         raw_annotations = dict(getattr(cls, "__annotations__", {}))
-        values_to_copy: dict[str, object] = {}
 
         for name, ann in type_hints.items():
             new_ann = _rewrite_with_optional(ann)
 
             if new_ann is not ann:
                 raw_annotations[name] = new_ann
-
-                # If value is inherited, copy it into subclass namespace
-                if name not in cls.__dict__ and hasattr(cls, name):
-                    values_to_copy[name] = getattr(cls, name)
-
-        for name, value in values_to_copy.items():
-            setattr(cls, name, value)
 
         if raw_annotations:
             cls.__annotations__ = raw_annotations

--- a/partial_tables/partial_table.py
+++ b/partial_tables/partial_table.py
@@ -108,14 +108,25 @@ class PartialSQLModelMixin:
             super().__init_subclass__(**kwargs)
             return
 
+        # Rewrite annotations to Optional[...] and ensure the corresponding Field(...)
+        # value from bases is present on the subclass namespace so SQLModel preserves
+        # unique/index/defaults when mapping.
         type_hints = get_type_hints(cls, include_extras=True)
         raw_annotations = dict(getattr(cls, "__annotations__", {}))
+        values_to_copy: dict[str, object] = {}
 
         for name, ann in type_hints.items():
             new_ann = _rewrite_with_optional(ann)
 
             if new_ann is not ann:
                 raw_annotations[name] = new_ann
+
+                # If value is inherited, copy it into subclass namespace
+                if name not in cls.__dict__ and hasattr(cls, name):
+                    values_to_copy[name] = getattr(cls, name)
+
+        for name, value in values_to_copy.items():
+            setattr(cls, name, value)
 
         if raw_annotations:
             cls.__annotations__ = raw_annotations

--- a/tests/integration/database/sqlmodel_tables.py
+++ b/tests/integration/database/sqlmodel_tables.py
@@ -14,8 +14,8 @@ class SQLModelBusinessBase(PartialSQLModelMixin, SQLModel):
 
     business_id: int = Field(primary_key=True, sa_column_kwargs={"autoincrement": True})
     business_name: str
-    city: Annotated[str, PartialAllowed()] = Field()
-    address: Annotated[str, PartialAllowed()] = Field()
+    city: Annotated[str, PartialAllowed()] = Field(unique=True)
+    address: Annotated[str, PartialAllowed()] = Field(index=True)
 
 
 class BusinessDraft(SQLModelBusinessBase, PartialTable, table=True):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds unique on `city` and index on `address` in the SQLModel test model and a test asserting Partial tables preserve these attributes.
> 
> - **Tests**:
>   - Add `test_preserves_column_attributes_on_partial` verifying Partial tables retain `unique`/`index` on columns using `UniqueConstraint`/`Index` checks.
> - **Test Models**:
>   - Update `tests/integration/database/sqlmodel_tables.py` to set `city` as `unique=True` and `address` as `index=True` on base model fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cbc59cb6c9239f5c3a4f50d25fbbd7158e9bc61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->