### PR TITLE
ci: run simplify-on-stop pre-push pass once per branch

### DIFF
--- a/.agents/hooks/simplify-on-stop.sh
+++ b/.agents/hooks/simplify-on-stop.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
-# Stop hook: nudge the agent to run claude-review and code-simplify over the
-# whole branch diff as a local pre-push pass. A stamp of HEAD + working-tree
-# content in the git dir limits the nudge to once per branch state — gating on
-# unpushed work would never fire in remote sessions, which push within the same
-# turn. `stop_hook_active` stops a second block in one stop cycle; if it cannot
-# be read, treat it as active — a skipped nudge beats an infinite Stop loop.
+# Stop hook: once per branch, nudge the agent to run claude-review and
+# code-simplify over the whole branch diff as a local pre-push pass — then stay
+# quiet. After a branch has been nudged once, later stops on it (the review
+# pass's own commit, CI-fix follow-ups, further tweaks) do NOT re-run the pass.
+# `stop_hook_active` guards the immediate continuation; a per-branch record in
+# the git dir guards every stop after that. If the active flag cannot be read,
+# treat it as active — a skipped nudge beats an infinite Stop loop.
 
 set -euo pipefail
 
@@ -23,33 +24,23 @@ is_active=$(printf '%s' "$input" | python3 -c \
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 
-# State = HEAD plus a hash of the actual working-tree content, so re-editing an
-# already-modified file changes the stamp and the pre-push pass fires again
-# instead of matching a stale stamp. `git diff --binary` folds in binary file
-# bytes; a portable read loop (no GNU-only `xargs -r`) hashes each untracked
-# file's path and contents.
-head_sha=$(git rev-parse HEAD 2>/dev/null || echo "no-head")
-porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
-dirty_sha=$(
-  {
-    git diff --binary HEAD 2>/dev/null || true
-    git ls-files --others --exclude-standard -z 2>/dev/null \
-      | while IFS= read -r -d '' file; do
-          printf '%s\0' "$file"
-          git hash-object "$file" 2>/dev/null || true
-        done
-  } | git hash-object --stdin 2>/dev/null || echo "hash-error"
-)
-state="$head_sha:$dirty_sha"
+# Key the once-per-branch record by branch name, or by HEAD sha when detached.
+branch_key=$(git symbolic-ref --quiet --short HEAD 2>/dev/null \
+  || git rev-parse HEAD 2>/dev/null || echo "")
+[ -n "$branch_key" ] || exit 0
 
-stamp_file="$git_dir/simplify-on-stop.stamp"
-[ -f "$stamp_file" ] && [ "$(cat "$stamp_file")" = "$state" ] && exit 0
+# Already nudged this branch — do not re-run the pass for the review's own
+# commit, a CI-fix follow-up push, or any later work on the same branch.
+nudged_file="$git_dir/simplify-on-stop.nudged"
+if [ -f "$nudged_file" ] && grep -qxF "$branch_key" "$nudged_file" 2>/dev/null; then
+  exit 0
+fi
 
-# Clean tree with no diff over the remote default branch means nothing to
-# review. Resolve the default via origin/HEAD, then fall back to whichever of
-# origin/main or origin/master exists; a missing ref or git error falls through
-# and still nudges.
-if [ -z "$porcelain" ]; then
+# Nothing to review when the tree is clean and HEAD has no diff over the remote
+# default branch. Resolve the default via origin/HEAD, then fall back to
+# whichever of origin/main or origin/master exists; a missing ref or git error
+# falls through and still nudges.
+if [ -z "$(git status --porcelain --untracked-files=normal 2>/dev/null)" ]; then
   default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || echo "")
   if [ -z "$default_ref" ]; then
     for cand in refs/remotes/origin/main refs/remotes/origin/master; do
@@ -64,6 +55,7 @@ if [ -z "$porcelain" ]; then
   fi
 fi
 
-printf '%s' "$state" > "$stamp_file"
+# Record this branch as nudged before blocking, so the pass runs exactly once.
+printf '%s\n' "$branch_key" >> "$nudged_file"
 
 echo '{"decision":"block","reason":"Run a LOCAL pre-push pass over the WHOLE branch diff versus the base branch, including uncommitted work — no GitHub PR required. First call the Skill tool with skill=\"claude-review\" in local mode and apply the real fixes directly (no PR, no asking, no branching off, no comment). Then call skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\") over the same diff and apply its simplifications. Commit the edits from both skills, and push them if the branch was already pushed. If the branch has no code changes, skip both skills and conclude."}'

--- a/.agents/hooks/simplify-on-stop.sh
+++ b/.agents/hooks/simplify-on-stop.sh
@@ -37,10 +37,13 @@ if [ -f "$nudged_file" ] && grep -qxF "$branch_key" "$nudged_file" 2>/dev/null; 
 fi
 
 # Nothing to review when the tree is clean and HEAD has no diff over the remote
-# default branch. Resolve the default via origin/HEAD, then fall back to
-# whichever of origin/main or origin/master exists; a missing ref or git error
-# falls through and still nudges.
-if [ -z "$(git status --porcelain --untracked-files=normal 2>/dev/null)" ]; then
+# default branch. An unreadable status falls back to a non-empty sentinel so it
+# is treated as "maybe dirty" and still nudges, rather than silently skipping.
+# Resolve the default via origin/HEAD, then fall back to whichever of
+# origin/main or origin/master exists; a missing ref or git error falls through
+# and still nudges.
+porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
+if [ -z "$porcelain" ]; then
   default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || echo "")
   if [ -z "$default_ref" ]; then
     for cand in refs/remotes/origin/main refs/remotes/origin/master; do

--- a/.agents/hooks/simplify-on-stop.sh
+++ b/.agents/hooks/simplify-on-stop.sh
@@ -24,10 +24,26 @@ is_active=$(printf '%s' "$input" | python3 -c \
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 
-# Key the once-per-branch record by branch name, or by HEAD sha when detached.
-branch_key=$(git symbolic-ref --quiet --short HEAD 2>/dev/null \
-  || git rev-parse HEAD 2>/dev/null || echo "")
-[ -n "$branch_key" ] || exit 0
+# Resolve the remote default branch once via origin/HEAD, then fall back to
+# whichever of origin/main or origin/master exists; reused for the detached-HEAD
+# key and the clean-tree skip below.
+default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || echo "")
+if [ -z "$default_ref" ]; then
+  for cand in refs/remotes/origin/main refs/remotes/origin/master; do
+    git rev-parse --verify --quiet "$cand" >/dev/null 2>&1 && { default_ref="$cand"; break; }
+  done
+fi
+
+# Key the once-per-branch record by branch name. On a detached HEAD there is no
+# branch name, so key on the fork point from the default branch — stable as the
+# detached line gains commits, unlike HEAD itself, which would rotate every
+# commit and re-fire the pass.
+branch_key=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || echo "")
+if [ -z "$branch_key" ]; then
+  fork_point=""
+  [ -n "$default_ref" ] && fork_point=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
+  branch_key="detached:${fork_point:-unknown}"
+fi
 
 # Already nudged this branch — do not re-run the pass for the review's own
 # commit, a CI-fix follow-up push, or any later work on the same branch.
@@ -38,23 +54,13 @@ fi
 
 # Nothing to review when the tree is clean and HEAD has no diff over the remote
 # default branch. An unreadable status falls back to a non-empty sentinel so it
-# is treated as "maybe dirty" and still nudges, rather than silently skipping.
-# Resolve the default via origin/HEAD, then fall back to whichever of
-# origin/main or origin/master exists; a missing ref or git error falls through
-# and still nudges.
+# is treated as "maybe dirty" and still nudges, rather than silently skipping. A
+# missing default ref or git error falls through and still nudges.
 porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
-if [ -z "$porcelain" ]; then
-  default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || echo "")
-  if [ -z "$default_ref" ]; then
-    for cand in refs/remotes/origin/main refs/remotes/origin/master; do
-      git rev-parse --verify --quiet "$cand" >/dev/null 2>&1 && { default_ref="$cand"; break; }
-    done
-  fi
-  if [ -n "$default_ref" ]; then
-    base=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
-    if [ -n "$base" ] && git diff --quiet "$base" HEAD 2>/dev/null; then
-      exit 0
-    fi
+if [ -z "$porcelain" ] && [ -n "$default_ref" ]; then
+  base=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
+  if [ -n "$base" ] && git diff --quiet "$base" HEAD 2>/dev/null; then
+    exit 0
   fi
 fi
 

--- a/.claude/hooks/simplify-on-stop.sh
+++ b/.claude/hooks/simplify-on-stop.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
-# Stop hook: nudge the agent to run claude-review and code-simplify over the
-# whole branch diff as a local pre-push pass. A stamp of HEAD + working-tree
-# content in the git dir limits the nudge to once per branch state — gating on
-# unpushed work would never fire in remote sessions, which push within the same
-# turn. `stop_hook_active` stops a second block in one stop cycle; if it cannot
-# be read, treat it as active — a skipped nudge beats an infinite Stop loop.
+# Stop hook: once per branch, nudge the agent to run claude-review and
+# code-simplify over the whole branch diff as a local pre-push pass — then stay
+# quiet. After a branch has been nudged once, later stops on it (the review
+# pass's own commit, CI-fix follow-ups, further tweaks) do NOT re-run the pass.
+# `stop_hook_active` guards the immediate continuation; a per-branch record in
+# the git dir guards every stop after that. If the active flag cannot be read,
+# treat it as active — a skipped nudge beats an infinite Stop loop.
 
 set -euo pipefail
 
@@ -23,33 +24,23 @@ is_active=$(printf '%s' "$input" | python3 -c \
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 
-# State = HEAD plus a hash of the actual working-tree content, so re-editing an
-# already-modified file changes the stamp and the pre-push pass fires again
-# instead of matching a stale stamp. `git diff --binary` folds in binary file
-# bytes; a portable read loop (no GNU-only `xargs -r`) hashes each untracked
-# file's path and contents.
-head_sha=$(git rev-parse HEAD 2>/dev/null || echo "no-head")
-porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
-dirty_sha=$(
-  {
-    git diff --binary HEAD 2>/dev/null || true
-    git ls-files --others --exclude-standard -z 2>/dev/null \
-      | while IFS= read -r -d '' file; do
-          printf '%s\0' "$file"
-          git hash-object "$file" 2>/dev/null || true
-        done
-  } | git hash-object --stdin 2>/dev/null || echo "hash-error"
-)
-state="$head_sha:$dirty_sha"
+# Key the once-per-branch record by branch name, or by HEAD sha when detached.
+branch_key=$(git symbolic-ref --quiet --short HEAD 2>/dev/null \
+  || git rev-parse HEAD 2>/dev/null || echo "")
+[ -n "$branch_key" ] || exit 0
 
-stamp_file="$git_dir/simplify-on-stop.stamp"
-[ -f "$stamp_file" ] && [ "$(cat "$stamp_file")" = "$state" ] && exit 0
+# Already nudged this branch — do not re-run the pass for the review's own
+# commit, a CI-fix follow-up push, or any later work on the same branch.
+nudged_file="$git_dir/simplify-on-stop.nudged"
+if [ -f "$nudged_file" ] && grep -qxF "$branch_key" "$nudged_file" 2>/dev/null; then
+  exit 0
+fi
 
-# Clean tree with no diff over the remote default branch means nothing to
-# review. Resolve the default via origin/HEAD, then fall back to whichever of
-# origin/main or origin/master exists; a missing ref or git error falls through
-# and still nudges.
-if [ -z "$porcelain" ]; then
+# Nothing to review when the tree is clean and HEAD has no diff over the remote
+# default branch. Resolve the default via origin/HEAD, then fall back to
+# whichever of origin/main or origin/master exists; a missing ref or git error
+# falls through and still nudges.
+if [ -z "$(git status --porcelain --untracked-files=normal 2>/dev/null)" ]; then
   default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || echo "")
   if [ -z "$default_ref" ]; then
     for cand in refs/remotes/origin/main refs/remotes/origin/master; do
@@ -64,6 +55,7 @@ if [ -z "$porcelain" ]; then
   fi
 fi
 
-printf '%s' "$state" > "$stamp_file"
+# Record this branch as nudged before blocking, so the pass runs exactly once.
+printf '%s\n' "$branch_key" >> "$nudged_file"
 
 echo '{"decision":"block","reason":"Run a LOCAL pre-push pass over the WHOLE branch diff versus the base branch, including uncommitted work — no GitHub PR required. First call the Skill tool with skill=\"claude-review\" in local mode and apply the real fixes directly (no PR, no asking, no branching off, no comment). Then call skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\") over the same diff and apply its simplifications. Commit the edits from both skills, and push them if the branch was already pushed. If the branch has no code changes, skip both skills and conclude."}'

--- a/.claude/hooks/simplify-on-stop.sh
+++ b/.claude/hooks/simplify-on-stop.sh
@@ -37,10 +37,13 @@ if [ -f "$nudged_file" ] && grep -qxF "$branch_key" "$nudged_file" 2>/dev/null; 
 fi
 
 # Nothing to review when the tree is clean and HEAD has no diff over the remote
-# default branch. Resolve the default via origin/HEAD, then fall back to
-# whichever of origin/main or origin/master exists; a missing ref or git error
-# falls through and still nudges.
-if [ -z "$(git status --porcelain --untracked-files=normal 2>/dev/null)" ]; then
+# default branch. An unreadable status falls back to a non-empty sentinel so it
+# is treated as "maybe dirty" and still nudges, rather than silently skipping.
+# Resolve the default via origin/HEAD, then fall back to whichever of
+# origin/main or origin/master exists; a missing ref or git error falls through
+# and still nudges.
+porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
+if [ -z "$porcelain" ]; then
   default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || echo "")
   if [ -z "$default_ref" ]; then
     for cand in refs/remotes/origin/main refs/remotes/origin/master; do

--- a/.claude/hooks/simplify-on-stop.sh
+++ b/.claude/hooks/simplify-on-stop.sh
@@ -24,10 +24,26 @@ is_active=$(printf '%s' "$input" | python3 -c \
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 
-# Key the once-per-branch record by branch name, or by HEAD sha when detached.
-branch_key=$(git symbolic-ref --quiet --short HEAD 2>/dev/null \
-  || git rev-parse HEAD 2>/dev/null || echo "")
-[ -n "$branch_key" ] || exit 0
+# Resolve the remote default branch once via origin/HEAD, then fall back to
+# whichever of origin/main or origin/master exists; reused for the detached-HEAD
+# key and the clean-tree skip below.
+default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || echo "")
+if [ -z "$default_ref" ]; then
+  for cand in refs/remotes/origin/main refs/remotes/origin/master; do
+    git rev-parse --verify --quiet "$cand" >/dev/null 2>&1 && { default_ref="$cand"; break; }
+  done
+fi
+
+# Key the once-per-branch record by branch name. On a detached HEAD there is no
+# branch name, so key on the fork point from the default branch — stable as the
+# detached line gains commits, unlike HEAD itself, which would rotate every
+# commit and re-fire the pass.
+branch_key=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || echo "")
+if [ -z "$branch_key" ]; then
+  fork_point=""
+  [ -n "$default_ref" ] && fork_point=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
+  branch_key="detached:${fork_point:-unknown}"
+fi
 
 # Already nudged this branch — do not re-run the pass for the review's own
 # commit, a CI-fix follow-up push, or any later work on the same branch.
@@ -38,23 +54,13 @@ fi
 
 # Nothing to review when the tree is clean and HEAD has no diff over the remote
 # default branch. An unreadable status falls back to a non-empty sentinel so it
-# is treated as "maybe dirty" and still nudges, rather than silently skipping.
-# Resolve the default via origin/HEAD, then fall back to whichever of
-# origin/main or origin/master exists; a missing ref or git error falls through
-# and still nudges.
+# is treated as "maybe dirty" and still nudges, rather than silently skipping. A
+# missing default ref or git error falls through and still nudges.
 porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
-if [ -z "$porcelain" ]; then
-  default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || echo "")
-  if [ -z "$default_ref" ]; then
-    for cand in refs/remotes/origin/main refs/remotes/origin/master; do
-      git rev-parse --verify --quiet "$cand" >/dev/null 2>&1 && { default_ref="$cand"; break; }
-    done
-  fi
-  if [ -n "$default_ref" ]; then
-    base=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
-    if [ -n "$base" ] && git diff --quiet "$base" HEAD 2>/dev/null; then
-      exit 0
-    fi
+if [ -z "$porcelain" ] && [ -n "$default_ref" ]; then
+  base=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
+  if [ -n "$base" ] && git diff --quiet "$base" HEAD 2>/dev/null; then
+    exit 0
   fi
 fi
 

--- a/.cursor/hooks/simplify-on-stop.sh
+++ b/.cursor/hooks/simplify-on-stop.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
-# Stop hook: nudge the agent to run claude-review and code-simplify over the
-# whole branch diff as a local pre-push pass. A stamp of HEAD + working-tree
-# content in the git dir limits the nudge to once per branch state — gating on
-# unpushed work would never fire in remote sessions, which push within the same
-# turn. `stop_hook_active` stops a second block in one stop cycle; if it cannot
-# be read, treat it as active — a skipped nudge beats an infinite Stop loop.
+# Stop hook: once per branch, nudge the agent to run claude-review and
+# code-simplify over the whole branch diff as a local pre-push pass — then stay
+# quiet. After a branch has been nudged once, later stops on it (the review
+# pass's own commit, CI-fix follow-ups, further tweaks) do NOT re-run the pass.
+# `stop_hook_active` guards the immediate continuation; a per-branch record in
+# the git dir guards every stop after that. If the active flag cannot be read,
+# treat it as active — a skipped nudge beats an infinite Stop loop.
 
 set -euo pipefail
 
@@ -23,33 +24,23 @@ is_active=$(printf '%s' "$input" | python3 -c \
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 
-# State = HEAD plus a hash of the actual working-tree content, so re-editing an
-# already-modified file changes the stamp and the pre-push pass fires again
-# instead of matching a stale stamp. `git diff --binary` folds in binary file
-# bytes; a portable read loop (no GNU-only `xargs -r`) hashes each untracked
-# file's path and contents.
-head_sha=$(git rev-parse HEAD 2>/dev/null || echo "no-head")
-porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
-dirty_sha=$(
-  {
-    git diff --binary HEAD 2>/dev/null || true
-    git ls-files --others --exclude-standard -z 2>/dev/null \
-      | while IFS= read -r -d '' file; do
-          printf '%s\0' "$file"
-          git hash-object "$file" 2>/dev/null || true
-        done
-  } | git hash-object --stdin 2>/dev/null || echo "hash-error"
-)
-state="$head_sha:$dirty_sha"
+# Key the once-per-branch record by branch name, or by HEAD sha when detached.
+branch_key=$(git symbolic-ref --quiet --short HEAD 2>/dev/null \
+  || git rev-parse HEAD 2>/dev/null || echo "")
+[ -n "$branch_key" ] || exit 0
 
-stamp_file="$git_dir/simplify-on-stop.stamp"
-[ -f "$stamp_file" ] && [ "$(cat "$stamp_file")" = "$state" ] && exit 0
+# Already nudged this branch — do not re-run the pass for the review's own
+# commit, a CI-fix follow-up push, or any later work on the same branch.
+nudged_file="$git_dir/simplify-on-stop.nudged"
+if [ -f "$nudged_file" ] && grep -qxF "$branch_key" "$nudged_file" 2>/dev/null; then
+  exit 0
+fi
 
-# Clean tree with no diff over the remote default branch means nothing to
-# review. Resolve the default via origin/HEAD, then fall back to whichever of
-# origin/main or origin/master exists; a missing ref or git error falls through
-# and still nudges.
-if [ -z "$porcelain" ]; then
+# Nothing to review when the tree is clean and HEAD has no diff over the remote
+# default branch. Resolve the default via origin/HEAD, then fall back to
+# whichever of origin/main or origin/master exists; a missing ref or git error
+# falls through and still nudges.
+if [ -z "$(git status --porcelain --untracked-files=normal 2>/dev/null)" ]; then
   default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || echo "")
   if [ -z "$default_ref" ]; then
     for cand in refs/remotes/origin/main refs/remotes/origin/master; do
@@ -64,6 +55,7 @@ if [ -z "$porcelain" ]; then
   fi
 fi
 
-printf '%s' "$state" > "$stamp_file"
+# Record this branch as nudged before blocking, so the pass runs exactly once.
+printf '%s\n' "$branch_key" >> "$nudged_file"
 
 echo '{"decision":"block","reason":"Run a LOCAL pre-push pass over the WHOLE branch diff versus the base branch, including uncommitted work — no GitHub PR required. First call the Skill tool with skill=\"claude-review\" in local mode and apply the real fixes directly (no PR, no asking, no branching off, no comment). Then call skill=\"code-simplify\" (the project skill, NOT the built-in \"simplify\") over the same diff and apply its simplifications. Commit the edits from both skills, and push them if the branch was already pushed. If the branch has no code changes, skip both skills and conclude."}'

--- a/.cursor/hooks/simplify-on-stop.sh
+++ b/.cursor/hooks/simplify-on-stop.sh
@@ -37,10 +37,13 @@ if [ -f "$nudged_file" ] && grep -qxF "$branch_key" "$nudged_file" 2>/dev/null; 
 fi
 
 # Nothing to review when the tree is clean and HEAD has no diff over the remote
-# default branch. Resolve the default via origin/HEAD, then fall back to
-# whichever of origin/main or origin/master exists; a missing ref or git error
-# falls through and still nudges.
-if [ -z "$(git status --porcelain --untracked-files=normal 2>/dev/null)" ]; then
+# default branch. An unreadable status falls back to a non-empty sentinel so it
+# is treated as "maybe dirty" and still nudges, rather than silently skipping.
+# Resolve the default via origin/HEAD, then fall back to whichever of
+# origin/main or origin/master exists; a missing ref or git error falls through
+# and still nudges.
+porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
+if [ -z "$porcelain" ]; then
   default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || echo "")
   if [ -z "$default_ref" ]; then
     for cand in refs/remotes/origin/main refs/remotes/origin/master; do

--- a/.cursor/hooks/simplify-on-stop.sh
+++ b/.cursor/hooks/simplify-on-stop.sh
@@ -24,10 +24,26 @@ is_active=$(printf '%s' "$input" | python3 -c \
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
 git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
 
-# Key the once-per-branch record by branch name, or by HEAD sha when detached.
-branch_key=$(git symbolic-ref --quiet --short HEAD 2>/dev/null \
-  || git rev-parse HEAD 2>/dev/null || echo "")
-[ -n "$branch_key" ] || exit 0
+# Resolve the remote default branch once via origin/HEAD, then fall back to
+# whichever of origin/main or origin/master exists; reused for the detached-HEAD
+# key and the clean-tree skip below.
+default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || echo "")
+if [ -z "$default_ref" ]; then
+  for cand in refs/remotes/origin/main refs/remotes/origin/master; do
+    git rev-parse --verify --quiet "$cand" >/dev/null 2>&1 && { default_ref="$cand"; break; }
+  done
+fi
+
+# Key the once-per-branch record by branch name. On a detached HEAD there is no
+# branch name, so key on the fork point from the default branch — stable as the
+# detached line gains commits, unlike HEAD itself, which would rotate every
+# commit and re-fire the pass.
+branch_key=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || echo "")
+if [ -z "$branch_key" ]; then
+  fork_point=""
+  [ -n "$default_ref" ] && fork_point=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
+  branch_key="detached:${fork_point:-unknown}"
+fi
 
 # Already nudged this branch — do not re-run the pass for the review's own
 # commit, a CI-fix follow-up push, or any later work on the same branch.
@@ -38,23 +54,13 @@ fi
 
 # Nothing to review when the tree is clean and HEAD has no diff over the remote
 # default branch. An unreadable status falls back to a non-empty sentinel so it
-# is treated as "maybe dirty" and still nudges, rather than silently skipping.
-# Resolve the default via origin/HEAD, then fall back to whichever of
-# origin/main or origin/master exists; a missing ref or git error falls through
-# and still nudges.
+# is treated as "maybe dirty" and still nudges, rather than silently skipping. A
+# missing default ref or git error falls through and still nudges.
 porcelain=$(git status --porcelain --untracked-files=normal 2>/dev/null || echo "status-error")
-if [ -z "$porcelain" ]; then
-  default_ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || echo "")
-  if [ -z "$default_ref" ]; then
-    for cand in refs/remotes/origin/main refs/remotes/origin/master; do
-      git rev-parse --verify --quiet "$cand" >/dev/null 2>&1 && { default_ref="$cand"; break; }
-    done
-  fi
-  if [ -n "$default_ref" ]; then
-    base=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
-    if [ -n "$base" ] && git diff --quiet "$base" HEAD 2>/dev/null; then
-      exit 0
-    fi
+if [ -z "$porcelain" ] && [ -n "$default_ref" ]; then
+  base=$(git merge-base "$default_ref" HEAD 2>/dev/null || echo "")
+  if [ -n "$base" ] && git diff --quiet "$base" HEAD 2>/dev/null; then
+    exit 0
   fi
 fi
 


### PR DESCRIPTION
Changes the Stop-hook pre-push pass (`simplify-on-stop.sh`, synced into the `.claude/` and `.cursor/` mirrors) to run **once per branch** instead of re-firing on every working-tree change.

Previously the stamp was keyed on `HEAD` + working-tree content, so the pass re-ran after its own review commit and again after each follow-up push (e.g. fixing a CI/Bugbot comment). Now the hook records each branch it has nudged in a per-branch file in the git dir; once a branch has been nudged, later stops on it — the review pass's own commit, CI-fix follow-ups, and further tweaks — do not re-trigger the pass. The record is keyed per branch, so concurrent branches stay independent.

`stop_hook_active` still guards the immediate continuation, and the clean-tree / no-diff-vs-default skip and bare-repo guard are unchanged.

Note on the trade-off: a branch gets the pre-push pass once per working copy; genuinely new work later on the same branch won't auto-trigger another pass (the review skill can still be invoked on demand).

https://claude.ai/code/session_01Qd5RpkdCL9ktzLrJgGugh5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qd5RpkdCL9ktzLrJgGugh5)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Agent hook behavior only; no app runtime, auth, or data paths. Main effect is fewer automatic review passes per branch.
> 
> **Overview**
> The **Stop hook** `simplify-on-stop.sh` (same change in `.agents/`, `.claude/`, and `.cursor/` copies) no longer re-triggers the local **claude-review** / **code-simplify** pre-push pass on every working-tree change.
> 
> **Gating** moves from a single `simplify-on-stop.stamp` keyed on `HEAD` plus a hash of tracked/untracked dirty content to **`simplify-on-stop.nudged`**, which appends one line per **branch key** (short branch name, or `detached:<merge-base>` on detached HEAD). After a branch is recorded, later stops on that branch—review commits, CI fixes, more edits—exit without blocking.
> 
> Default-branch resolution (`origin/HEAD` → `origin/main` / `origin/master`) is hoisted so it is shared by detached-HEAD keys and the existing **clean tree + no diff vs default** early exit. Unreadable `git status` still uses a non-empty sentinel so the hook may nudge instead of skipping silently.
> 
> **Trade-off:** further work on the same branch in one clone will not auto-run the pass again; skills can still be invoked manually.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cef2539118f299cf47a247f83b81a39c1ef0e2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->