### PR TITLE
Capitalize the code review job name to Review

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -12,7 +12,7 @@ permissions:
   checks: write
 
 jobs:
-  review:
+  Review:
     runs-on: ubuntu-latest
     concurrency:
       group: code-review-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name == 'issue_comment' && 'comment' || 'review' }}


### PR DESCRIPTION
Rename the workflow job id `review` → `Review` so the PR check displays as **Review** instead of **review**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qd5RpkdCL9ktzLrJgGugh5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qd5RpkdCL9ktzLrJgGugh5)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic workflow job id change with no runtime or security impact.
> 
> **Overview**
> Renames the GitHub Actions job id in `code-review.yml` from `review` to **`Review`** so the PR check label shows as **Review** instead of lowercase **review**.
> 
> No steps, triggers, permissions, or action configuration are changed—only the job key used for display in the checks UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e7b545ca85ed756417053fd573d8b9c1f7ffe82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->